### PR TITLE
qcacld-2.0: Fix stack corruption in sme_RrmProcessNeighborReport()

### DIFF
--- a/drivers/staging/qcacld-2.0/CORE/SME/src/rrm/sme_rrm.c
+++ b/drivers/staging/qcacld-2.0/CORE/SME/src/rrm/sme_rrm.c
@@ -1184,7 +1184,7 @@ void rrmStoreNeighborRptByRoamScore(tpAniSirGlobal pMac, tpRrmNeighborReportDesc
   \sa
 
   --------------------------------------------------------------------------*/
-eHalStatus sme_RrmProcessNeighborReport(tpAniSirGlobal pMac, void *pMsgBuf)
+eHalStatus __attribute__((optimize("O0"))) sme_RrmProcessNeighborReport(tpAniSirGlobal pMac, void *pMsgBuf)
 {
    eHalStatus status = eHAL_STATUS_SUCCESS;
    tpSirNeighborReportInd pNeighborRpt = (tpSirNeighborReportInd) pMsgBuf;


### PR DESCRIPTION
GCC is not quite optimizing something correctly inside
sme_RrmProcessNeighborReport(), causing rampant stack corruption while
connected to an AirPort router.

All of the code inside sme_RrmProcessNeighborReport() is sound; the way it
is written should not cause stack corruption, so the source of the issue
is unclear.

Disable GCC optimizations specifically for sme_RrmProcessNeighborReport()
to fix the stack corruption until an actual solution is found.

Change-Id: I3908071485e389f104073fe2d6a51884b42e9079
Signed-off-by: Sultanxda sultanxda@gmail.com
